### PR TITLE
*/terraform-*: Drop '$(pwd)/' from cp

### DIFF
--- a/buildah-from-alpine/terraform-alpine.sh
+++ b/buildah-from-alpine/terraform-alpine.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from alpine) || (echo "Must be root to execute buildah" && exit 1)
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-alpine:v0.11.7

--- a/buildah-from-scratch/terraform-fmt-from-scratch.sh
+++ b/buildah-from-scratch/terraform-fmt-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config --entrypoint='/terraform fmt -list -check -write=false' $ctr
 buildah commit $ctr terraform-scratch:v0.11.7

--- a/buildah-from-scratch/terraform-from-scratch.sh
+++ b/buildah-from-scratch/terraform-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-scratch:v0.11.7


### PR DESCRIPTION
Relative paths like `terraform` are expanded form the current working directory anyway, so we don't need this extra command substitution.

Also, it would be nice to drop a `LICENSE` or `COPYING` into this repo.  I expect this change is way smaller than anything copyrightable, but it would be nice to know I could legally copy and modify your work to work up this PR ;).