### PR TITLE
terraform-from-scratch: Set terraform as the entrypoint

### DIFF
--- a/buildah-from-alpine/terraform-alpine.sh
+++ b/buildah-from-alpine/terraform-alpine.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from alpine) || (echo "Must be root to execute buildah" && exit 1)
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-alpine:v0.11.7

--- a/buildah-from-scratch/terraform-fmt-from-scratch.sh
+++ b/buildah-from-scratch/terraform-fmt-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config --entrypoint='/terraform fmt -list -check -write=false' $ctr
 buildah commit $ctr terraform-scratch:v0.11.7

--- a/buildah-from-scratch/terraform-from-scratch.sh
+++ b/buildah-from-scratch/terraform-from-scratch.sh
@@ -11,7 +11,7 @@ wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd6
 unzip terraform_0.11.7_linux_amd64.zip
 cp terraform $mnt || exit 1
 buildah unmount $ctr
-buildah config $ctr
+buildah config --entrypoint='["/terraform"]' "${ctr}"
 buildah commit $ctr terraform-scratch:v0.11.7
 set +x
 echo "run 'podman run -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw terraform-scratch:v0.11.7 fmt -list -check -write=false' to terraform fmt source"

--- a/buildah-from-scratch/terraform-from-scratch.sh
+++ b/buildah-from-scratch/terraform-from-scratch.sh
@@ -10,10 +10,11 @@ mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
 cp terraform $mnt || exit 1
+mkdir $mnt/tmp || exit 1
 buildah unmount $ctr
 buildah config --entrypoint='["/terraform"]' "${ctr}"
 buildah commit $ctr terraform-scratch:v0.11.7
 set +x
-echo "run 'podman run -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw terraform-scratch:v0.11.7 fmt -list -check -write=false' to terraform fmt source"
+echo "run 'podman run -v "$PWD":"$PWD":ro terraform-scratch:v0.11.7 fmt -list -check -write=false' to terraform fmt source"
 echo "to cleanup run 'podman stop [containerid from podman run]; podman rm [containerid from podman run]'"
 echo "to push to docker-daemon run 'buildah push [imageID] docker-daemon:terraform-scratch:v0.11.7'"

--- a/buildah-from-scratch/terraform-from-scratch.sh
+++ b/buildah-from-scratch/terraform-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-scratch:v0.11.7


### PR DESCRIPTION
Builds on #1; review that first.

So you can run the container as if it were a terraform executable installed on your host system.  I'm not sure if/how the previous `fmt` example worked without this.