### PR TITLE
terraform-alpine: Install terraform into $PATH

### DIFF
--- a/buildah-from-alpine/terraform-alpine.sh
+++ b/buildah-from-alpine/terraform-alpine.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from alpine) || (echo "Must be root to execute buildah" && exit 1)
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-alpine:v0.11.7

--- a/buildah-from-alpine/terraform-alpine.sh
+++ b/buildah-from-alpine/terraform-alpine.sh
@@ -14,6 +14,6 @@ buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-alpine:v0.11.7
 set +x
-echo "run 'podman run -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw terraform-alpine:v0.11.7 terraform fmt -list -check -write=false' to terraform fmt source"
+echo "run 'podman run -v "$PWD":"$PWD":ro terraform-alpine:v0.11.7 terraform fmt -list -check -write=false' to terraform fmt source"
 echo "to cleanup run 'podman stop [containerid from podman run]; podman rm [containerid from podman run]'"
 echo "to push to docker-daemon run 'buildah push [imageID] docker-daemon:terraform-alpine:v0.11.7'"

--- a/buildah-from-alpine/terraform-alpine.sh
+++ b/buildah-from-alpine/terraform-alpine.sh
@@ -9,11 +9,11 @@ ctr=$(buildah from alpine) || (echo "Must be root to execute buildah" && exit 1)
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp terraform $mnt || exit 1
+cp terraform "${mnt}/usr/bin" || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-alpine:v0.11.7
 set +x
-echo "run 'podman run -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw terraform-alpine:v0.11.7 /terraform fmt -list -check -write=false' to terraform fmt source"
+echo "run 'podman run -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw terraform-alpine:v0.11.7 terraform fmt -list -check -write=false' to terraform fmt source"
 echo "to cleanup run 'podman stop [containerid from podman run]; podman rm [containerid from podman run]'"
 echo "to push to docker-daemon run 'buildah push [imageID] docker-daemon:terraform-alpine:v0.11.7'"

--- a/buildah-from-scratch/terraform-fmt-from-scratch.sh
+++ b/buildah-from-scratch/terraform-fmt-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config --entrypoint='/terraform fmt -list -check -write=false' $ctr
 buildah commit $ctr terraform-scratch:v0.11.7

--- a/buildah-from-scratch/terraform-from-scratch.sh
+++ b/buildah-from-scratch/terraform-from-scratch.sh
@@ -9,7 +9,7 @@ ctr=$(buildah from scratch) || (echo "Must be root to execute buildah" && exit 1
 mnt=`buildah mount $ctr` || (echo "Must be root to execute buildah" && exit 1)
 wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
 unzip terraform_0.11.7_linux_amd64.zip
-cp $(pwd)/terraform $mnt || exit 1
+cp terraform $mnt || exit 1
 buildah unmount $ctr
 buildah config $ctr
 buildah commit $ctr terraform-scratch:v0.11.7


### PR DESCRIPTION
Builds on #1; review that first.

Installing it without the leading slash makes invoking terraform via this container more like invoking terraform installed locally on the host system (e.g. via a package manager).